### PR TITLE
Fix/40 auth error

### DIFF
--- a/backend/src/main/java/com/project2/domain/member/controller/MemberController.java
+++ b/backend/src/main/java/com/project2/domain/member/controller/MemberController.java
@@ -89,7 +89,7 @@ public class MemberController {
 	}
 
 	@Operation(summary = "전체 회원 조회")
-	@GetMapping
+	@GetMapping("/totalMember")
 	public RsData<List<MemberDTO>> getAllMembers() {
 		List<Member> members = memberService.findAllMembers(); // 모든 회원을 조회하는 메서드 호출
 		List<MemberDTO> memberDTOs = members.stream()

--- a/frontend/src/app/ClientLayout.tsx
+++ b/frontend/src/app/ClientLayout.tsx
@@ -4,7 +4,11 @@ import { client } from "@/lib/backend/client";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
-import { getAccessTokenFromCookie, getUserIdFromToken } from "@/app/utils/auth";
+import {
+  saveAccessTokenFromCookie,
+  getAccessToken,
+  getUserIdFromToken,
+} from "@/app/utils/auth";
 
 export default function ClientLayout({
   children,
@@ -20,7 +24,8 @@ export default function ClientLayout({
   useEffect(() => {
     if (typeof window === "undefined") return;
 
-    const storedToken = getAccessTokenFromCookie();
+    saveAccessTokenFromCookie();
+    const storedToken = getAccessToken();
 
     if (storedToken) {
       setIsLogin(true);
@@ -33,7 +38,7 @@ export default function ClientLayout({
       return;
     }
 
-    // 로그인이 되지 않은 상태이고, 토큰이 없는경우 localStorage 에 accessToken 을 저장
+    // 로그인이 되지 않은 상태이고, 토큰이 없는경우 sessionStorage 에 accessToken 을 저장
     const checkLoginStatus = async () => {
       try {
         const response = await client.GET("/api/members/me", {
@@ -41,6 +46,7 @@ export default function ClientLayout({
         });
 
         if (response.data?.data) {
+          saveAccessTokenFromCookie();
           setIsLogin(true);
         } else {
         }

--- a/frontend/src/app/member/logout/ClientPage.tsx
+++ b/frontend/src/app/member/logout/ClientPage.tsx
@@ -15,7 +15,7 @@ export default function LogoutPage() {
         console.error("로그아웃 실패:", error);
       }
       removeAccessToken();
-      localStorage.clear();
+      sessionStorage.clear();
       router.replace("/member/login");
     }
 

--- a/frontend/src/app/utils/auth.ts
+++ b/frontend/src/app/utils/auth.ts
@@ -14,7 +14,7 @@ function decodeJWT(token: string) {
 }
 
 // 쿠키에서 Access Token 가져오기
-export function getAccessTokenFromCookie(): string | null {
+export function getAccessTokenFromCookie() {
   return (
     document.cookie
       .split("; ")
@@ -23,26 +23,31 @@ export function getAccessTokenFromCookie(): string | null {
   );
 }
 
-// Access Token에서 id 추출하기 (쿠키 기반)
-export function getUserIdFromToken(): string | null {
-  const token = getAccessTokenFromCookie(); // 쿠키에서 가져오기
+// Access Token에서 id 추출하기
+export function getUserIdFromToken() {
+  const token = getAccessToken(); // getAccessToken()을 사용하여 안전하게 가져옴
   if (!token) return null;
 
   const payload = decodeJWT(token);
-  return payload?.id || null; // JWT payload에 있는 id 반환
+  return payload?.id || null; // id가 JWT payload에 있는 경우 반환
 }
 
-// Access Token을 쿠키에 저장하기
-export function saveAccessTokenToCookie(
-  token: string,
-  expiresIn: number = 3600
-) {
-  const expires = new Date(Date.now() + expiresIn * 1000).toUTCString();
-  document.cookie = `accessToken=${token}; path=/; expires=${expires}; Secure; HttpOnly`;
+// Access Token을 sessionStorage에 저장
+export function saveAccessTokenFromCookie() {
+  const accessToken = getAccessTokenFromCookie();
+  if (accessToken) {
+    sessionStorage.setItem("accessToken", accessToken);
+  }
 }
 
-// Access Token 삭제 (쿠키에서 제거)
+// accessToken 불러오기
+export function getAccessToken(): string | null {
+  return typeof window !== "undefined"
+    ? sessionStorage.getItem("accessToken")
+    : null;
+}
+
+// Access Token 삭제 (sessionStorage에서 제거)
 export function removeAccessToken() {
-  document.cookie =
-    "accessToken=; path=/; expires=Thu, 01 Jan 1970 00:00:00 UTC;";
+  sessionStorage.removeItem("accessToken");
 }


### PR DESCRIPTION
## ✨ 변경 사항 설명
GetMapping이 동일하여 member가 정상적으로 되지 않는 현상 수정
cookie -> SessionStorage로 인증키를 불러올 수 있는 방향을 수정

localStorage와 cookie는 브라우저를 종료해도 데이터가 유지되므로, 만료된 토큰이 남아 있을 경우 불필요한 인증 과정이 발생할 수 있습니다.  
반면, sessionStorage는 브라우저 종료 시 자동으로 삭제되므로, 새로운 세션이 시작될 때 즉시 accessToken을 발급할 수 있습니다.


## ✅ 체크리스트

<!-- 📝 완료된 항목은 [x]로 표시해주세요. -->

- [ ] 🏗️ 코드가 **코딩 스타일 가이드**를 준수합니다.
- [x] 🧪 변경 사항에 대한 **테스트가 추가**되었습니다.
- [x] ✅ 모든 **테스트가 정상적으로 통과**합니다.
- [ ] 📚 필요한 **문서가 업데이트**되었습니다.

## 🎨 스크린샷 (UI 변경이 있는 경우)

<!-- 🖼️ 변경 전/후 스크린샷을 추가해주세요. -->

## 🛠️ 테스트 방법 (필요시)

<!-- 🧑‍💻 이 PR을 테스트하는 방법을 설명해주세요. -->
