### PR TITLE
[fix] region 데이터 불일치 수정

### DIFF
--- a/backend/src/main/java/com/project2/domain/place/enums/Region.java
+++ b/backend/src/main/java/com/project2/domain/place/enums/Region.java
@@ -7,9 +7,9 @@ import lombok.Getter;
 
 @Getter
 public enum Region {
-	SEOUL("서울특별시"), BUSAN("부산광역시"), DAEGU("대구광역시"), INCHEON("인천광역시"), GWANGJU("광주광역시"), DAEJEON("대전광역시"), ULSAN(
-		"울산광역시"), SEJONG("세종특별자치시"), GYEONGGI("경기도"), GANGWON("강원특별자치도"), CHUNGBUK("충청북도"), CHUNGNAM("충청남도"), JEONBUK(
-		"전라북도"), JEONNAM("전라남도"), GYEONGBUK("경상북도"), GYEONGNAM("경상남도"), JEJU("제주특별자치도"), ETC("기타");
+	SEOUL("서울"), BUSAN("부산"), DAEGU("대구"), INCHEON("인천"), GWANGJU("광주"), DAEJEON("대전"), ULSAN(
+		"울산"), SEJONG("세종특별자치시"), GYEONGGI("경기"), GANGWON("강원특별자치도"), CHUNGBUK("충북"), CHUNGNAM("충남"), JEONBUK(
+		"전북특별자치도"), JEONNAM("전남"), GYEONGBUK("경북"), GYEONGNAM("경남"), JEJU("제주특별자치도"), ETC("기타");
 
 	private final String krRegion;
 


### PR DESCRIPTION
## ✨ 변경 사항 설명
- 카카오맵 api 내부 지역 데이터와 프로젝트 지역 enum의 데이터 불일치로 지역이 모두 기타로 저장되는 문제 해결
-
## ✅ 체크리스트

<!-- 📝 완료된 항목은 [x]로 표시해주세요. -->

- [ ] 🏗️ 코드가 **코딩 스타일 가이드**를 준수합니다.
- [ ] 🧪 변경 사항에 대한 **테스트가 추가**되었습니다.
- [ ] ✅ 모든 **테스트가 정상적으로 통과**합니다.
- [ ] 📚 필요한 **문서가 업데이트**되었습니다.

## 🎨 스크린샷 (UI 변경이 있는 경우)

<!-- 🖼️ 변경 전/후 스크린샷을 추가해주세요. -->

## 🛠️ 테스트 방법 (필요시)

<!-- 🧑‍💻 이 PR을 테스트하는 방법을 설명해주세요. -->
